### PR TITLE
check for signal existence before registering in handler

### DIFF
--- a/attachtty.c
+++ b/attachtty.c
@@ -97,8 +97,45 @@ void suspend_myself(void) {
 static void init_signal_handlers(void) {
     struct sigaction act;
     int fatal_sig[] = {
-        SIGHUP, SIGQUIT, SIGILL, SIGABRT, SIGBUS, SIGFPE, SIGSEGV,
-        SIGPIPE, SIGTERM, SIGSTKFLT, SIGCHLD, SIGXCPU, SIGXFSZ,
+#ifdef SIGHUP
+        SIGHUP,
+#endif
+#ifdef SIGQUIT
+        SIGQUIT,
+#endif
+#ifdef SIGILL
+        SIGILL,
+#endif
+#ifdef SIGABRT
+        SIGABRT,
+#endif
+#ifdef SIGBUS
+        SIGBUS,
+#endif
+#ifdef SIGFPE
+        SIGFPE,
+#endif
+#ifdef SIGSEGV
+        SIGSEGV,
+#endif
+#ifdef SIGPIPE
+        SIGPIPE,
+#endif
+#ifdef SIGTERM
+        SIGTERM,
+#endif
+#ifdef SIGSTKFLT
+        SIGSTKFLT,
+#endif
+#ifdef SIGCHLD
+        SIGCHLD,
+#endif
+#ifdef SIGXCPU
+        SIGXCPU,
+#endif
+#ifdef SIGXFSZ
+        SIGXFSZ,
+#endif
     };
     unsigned i;
     

--- a/detachtty.c
+++ b/detachtty.c
@@ -395,8 +395,45 @@ static void sighup_signal_handler(int sig) {
 static void init_signal_handlers(void) {
     struct  sigaction act;
     int fatal_sig[] = {
-        SIGHUP, SIGQUIT, SIGILL, SIGABRT, SIGBUS, SIGFPE, SIGSEGV,
-        /*SIGPIPE,*/ SIGTERM, SIGSTKFLT, SIGCHLD, SIGXCPU, SIGXFSZ,
+#ifdef SIGHUP
+        SIGHUP,
+#endif
+#ifdef SIGQUIT
+        SIGQUIT,
+#endif
+#ifdef SIGILL
+        SIGILL,
+#endif
+#ifdef SIGABRT
+        SIGABRT,
+#endif
+#ifdef SIGBUS
+        SIGBUS,
+#endif
+#ifdef SIGFPE
+        SIGFPE,
+#endif
+#ifdef SIGSEGV
+        SIGSEGV,
+#endif
+#ifdef SIGPIPE
+        /*SIGPIPE,*/
+#endif
+#ifdef SIGTERM
+        SIGTERM,
+#endif
+#ifdef SIGSTKFLT
+        SIGSTKFLT,
+#endif
+#ifdef SIGCHLD
+        SIGCHLD,
+#endif
+#ifdef SIGXCPU
+        SIGXCPU,
+#endif
+#ifdef SIGXFSZ
+        SIGXFSZ,
+#endif
     };
     unsigned i;
 


### PR DESCRIPTION
Some signals are only defined on certain platforms.  For example,
SIGSTKFLT does not exist on sparc.  Use preprocessor macros to check for
signal's existence before registering signal handler for it.

Note that this is the same technique cpython uses:
https://github.com/python/cpython/blob/3.10/Modules/signalmodule.c#L1427

See: https://bugs.gentoo.org/807184